### PR TITLE
${req.baseUrl}${req.url} -> ${req.originalUrl}

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ class Signature implements Types.Signature {
     }
 
     verifyUrl(req: Request, addressReader?: Types.AddressReader): Types.VerifyResult {
-        const url = `${req.protocol}://${req.get('host')}${req.baseUrl}${req.url}`;
+        const url = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
 
         if( url.length < 33  ||  !this.verifyString( url.substring(0, url.length-32), url.substr(-32) ) ) {
             return Types.VerifyResult.blackholed;


### PR DESCRIPTION
app.use(... signature.verifier(), ...) - not works, as ${req.baseUrl}${req.url} would return different value on app.get() and app.use() use. 
Example url - 'https://github.com?signed=r:somenumbers', but ${req.baseUrl}${req.url} returns 'https://github.com/?signed=r:somenumbers' (/ - before ?signed) so hash is not equal.
Use ${req.originalUrl} - not ${req.baseUrl}${req.url}